### PR TITLE
Doesn't work without another resetInflections, and doesn't work on 'comments'

### DIFF
--- a/spec/inflector_spec.js
+++ b/spec/inflector_spec.js
@@ -149,6 +149,11 @@ describe( 'underscore.inflector', function( )
     {
       expect( _.singularize( 'post' ) ).toEqual( 'post' );
     } );
+
+    it( 'should singularize a word that contains an irregular', function( )
+    {
+      expect( _.singularize( 'comments' ) ).toEqual( 'comment' );
+    } );
   } );
   
   describe( 'singular', function( )

--- a/src/underscore.inflection.js
+++ b/src/underscore.inflection.js
@@ -87,8 +87,8 @@
 
     irregular : function( singular, plural )
     {
-      this.plural( singular, plural );
-      this.singular( plural, singular );
+      this.plural( '\\b' + singular + '\\b', plural );
+      this.singular( '\\b' + plural + '\\b', singular );
     },
 
     uncountable : function( word )


### PR DESCRIPTION
Doesn't work on initial load because the rules are stored in instance members that are not mixed in by underscore. Moved them into the closure so they will be accessible by the mixed in functions without being mixed in themselves.

Also fixed irregulars being processed when they are part of another word.
